### PR TITLE
Allow for class parameters for yumrepo resource management.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2017-10-05 Release 1.1.0
+- Added parameters to allow for more refined configuration of the yumrepo resources
+
 2017-10-04 Release 1.0.0
 - Changed files for use of hiera 5 and removed params.pp file
 - Modified service_name parameter to partekflowd to reflect actual service name installed

--- a/README.markdown
+++ b/README.markdown
@@ -52,7 +52,7 @@ include partekflow
 
 ```puppet
 class { 'partekflow':
-    config_catalina_tmpdir => '/home/flow/partek_flow/temp',
+  config_catalina_tmpdir => '/home/flow/partek_flow/temp',
 }
 ```
 
@@ -67,9 +67,37 @@ partekflow::config_catalina_tmpdir: '/home/flow/partek_flow/temp'
 
 ```puppet
 class { 'partekflow':
-    config_template => 'module_name/path/to/template.erb',
+  config_template => 'module_name/path/to/template.erb',
 }
 ```
+
+### To disable the stable repsitory files but still have them present in /etc/yum.repos.d/
+
+```puppet
+class { 'partekflow':
+  yumrepo_ensure_stable  => true,
+  yumrepo_enabled_stable => false,
+}
+```
+
+### To use a local repository mirror instead of the Partek repositories
+
+```puppet
+class { 'partekflow':
+  yumrepo_baseurl_server       => 'http://yum.example.com',
+  yumrepo_baseurl_stablepath   => '/path/to/stable',
+  yumrepo_baseurl_unstablepath => '/path/to/unstable',
+}
+```
+
+### To remove the unstable /etc/yum.repos.d/ files
+
+```puppet
+class { 'partekflow':
+  ensure_unstable => false,
+}
+```
+
 
 ## Reference
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -19,3 +19,11 @@ partekflow::user_managehome: true
 partekflow::user_name: 'flow'
 partekflow::user_shell: '/bin/sh'
 partekflow::user_uid: 495
+partekflow::yumrepo_baseurl_server: ~
+partekflow::yumrepo_baseurl_stablepath: ~
+partekflow::yumrepo_baseurl_unstablepath: ~
+partekflow::yumrepo_enabled_stable: ~
+partekflow::yumrepo_enabled_unstable: ~
+partekflow::yumrepo_ensure_stable: ~
+partekflow::yumrepo_ensure_unstable: ~
+partekflow::yumrepo_manage: ~

--- a/data/osfamily/RedHat.yaml
+++ b/data/osfamily/RedHat.yaml
@@ -1,1 +1,10 @@
 ---
+
+partekflow::yumrepo_baseurl_server: 'http://packages.partek.com'
+partekflow::yumrepo_baseurl_stablepath: '/redhat/stable'
+partekflow::yumrepo_baseurl_unstablepath: '/redhat/unstable'
+partekflow::yumrepo_enabled_stable: true
+partekflow::yumrepo_enabled_unstable: false
+partekflow::yumrepo_ensure_stable: true
+partekflow::yumrepo_ensure_unstable: true
+partekflow::yumrepo_manage: true

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,14 @@
 # @param user_name [String] The user used to run the partekflowd server. Default value: flow.
 # @param user_shell [Stdlib::Absolutepath] User shell. Default value: /bin/sh
 # @param user_uid [Integer[1, 999]] The uid of the user to create for the partekflowd server. Default value: 495.
+# @param yumrepo_baseurl_server [Optional Stdlib::Httpurl] URI of repository server. Default value (on osfamily=RedHat): http://packages.partek.com
+# @param yumrepo_baseurl_stablepath [Optional String] path to the location of the stable repositories not including the architecture portion (i.e. basearch or noarch). Default value (on osfamily=RedHat): /redhat/stable
+# @param yumrepo_baseurl_unstablepath [Optional String] path to the location of the unstable package repositories not including the architecture portion (i.e. basearch or noarch). Default value (on osfamily=RedHat): /redhat/unstable
+# @param yumrepo_enabled_stable [Optional Boolean] Whether or not to enable the stable yumrepo resources. Default value (on osfamily=RedHat): true
+# @param yumrepo_enabled_unstable [Optional Boolean] Whether or not to enable the unstable yumrepo resources. Default value (on osfamily=RedHat): false
+# @param yumrepo_ensure_stable [Optional Boolean] Specifies if the stable yumrepos.d config files should be present (true) or absent (false). Default value (on osfamily=RedHat): true
+# @param yumrepo_ensure_unstable [Optional Boolean] Specifies if the unstable yumrepos.d config files should be present (true) or absent (false). Default value (on osfamily=RedHat): true
+# @param yumrepo_manage [Optional Boolean] Whether or not to manage the package repositories. Default value (on osfamily=RedHat): true.
 class partekflow (
   Stdlib::Absolutepath $config_catalina_tmpdir,
   Stdlib::Absolutepath $config_file,
@@ -42,6 +50,14 @@ class partekflow (
   String $user_name,
   Stdlib::Absolutepath $user_shell,
   Integer[1, 999] $user_uid,
+  Optional[Stdlib::Httpurl] $yumrepo_baseurl_server,
+  Optional[String] $yumrepo_baseurl_stablepath,
+  Optional[String] $yumrepo_baseurl_unstablepath,
+  Optional[Boolean] $yumrepo_enabled_stable,
+  Optional[Boolean] $yumrepo_enabled_unstable,
+  Optional[Boolean] $yumrepo_ensure_stable,
+  Optional[Boolean] $yumrepo_ensure_unstable,
+  Optional[Boolean] $yumrepo_manage,
 ) {
 
   # validate parameters here

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -34,40 +34,73 @@ class partekflow::install {
   gpg_key { 'partek-public.key':
     path => '/etc/pki/rpm-gpg/partek-public.key',
   }
-  yumrepo { 'partekrepo-stable':
-    ensure   => present,
-    baseurl  => 'http://packages.partek.com/redhat/stable/$basearch',
-    enabled  => 1,
-    gpgcheck => 0,
-    gpgkey   => 'file:///etc/pki/rpm-gpg/partek-public.key',
-    require  => Gpg_key['partek-public.key'],
+  if $::partekflow::yumrepo_manage {
+    if $::partekflow::yumrepo_enabled_stable {
+      $enabled_stable = '1'
+    }
+    else {
+      $enabled_stable = '0'
+    }
+    if $::partekflow::yumrepo_enabled_unstable {
+      $enabled_unstable = '1'
+    }
+    else {
+      $enabled_unstable = '0'
+    }
+    if $::partekflow::yumrepo_ensure_stable {
+      $ensure_stable = 'present'
+    }
+    else {
+      $ensure_stable = 'absent'
+    }
+    if $::partekflow::yumrepo_ensure_unstable {
+      $ensure_unstable = 'present'
+    }
+    else {
+      $ensure_unstable = 'absent'
+    }
+    yumrepo { 'partekrepo-stable':
+      ensure   => $ensure_stable,
+      baseurl  => "${::partekflow::yumrepo_baseurl_server}${::partekflow::yumrepo_baseurl_stablepath}/\$basearch",
+      enabled  => $enabled_stable,
+      gpgcheck => 0,
+      gpgkey   => 'file:///etc/pki/rpm-gpg/partek-public.key',
+      require  => Gpg_key['partek-public.key'],
+    }
+    yumrepo { 'partekrepo-noarch-stable':
+      ensure   => $ensure_stable,
+      baseurl  => "${::partekflow::yumrepo_baseurl_server}${::partekflow::yumrepo_baseurl_stablepath}/noarch",
+      enabled  => $enabled_stable,
+      gpgcheck => 0,
+      gpgkey   => 'file:///etc/pki/rpm-gpg/partek-public.key',
+      require  => Gpg_key['partek-public.key'],
+    }
+    yumrepo { 'partekrepo-unstable':
+      ensure   => $ensure_unstable,
+      baseurl  => "${::partekflow::yumrepo_baseurl_server}${::partekflow::yumrepo_baseurl_unstablepath}/\$basearch",
+      enabled  => $enabled_unstable,
+      gpgcheck => 0,
+      gpgkey   => 'file:///etc/pki/rpm-gpg/partek-public.key',
+      require  => Gpg_key['partek-public.key'],
+    }
+    yumrepo { 'partekrepo-noarch-unstable':
+      ensure   => $ensure_unstable,
+      baseurl  => "${::partekflow::yumrepo_baseurl_server}${::partekflow::yumrepo_baseurl_unstablepath}/noarch",
+      enabled  => $enabled_unstable,
+      gpgcheck => 0,
+      gpgkey   => 'file:///etc/pki/rpm-gpg/partek-public.key',
+      require  => Gpg_key['partek-public.key'],
+    }
+    package { $::partekflow::package_name:
+      ensure  => $::partekflow::package_ensure,
+      require => [ User[$::partekflow::user_name], Yumrepo['partekrepo-stable'], Yumrepo['partekrepo-noarch-stable'], ],
+    }
   }
-  yumrepo { 'partekrepo-noarch-stable':
-    ensure   => present,
-    baseurl  => 'http://packages.partek.com/redhat/stable/noarch',
-    enabled  => 1,
-    gpgcheck => 0,
-    gpgkey   => 'file:///etc/pki/rpm-gpg/partek-public.key',
-    require  => Gpg_key['partek-public.key'],
-  }
-  yumrepo { 'partekrepo-unstable':
-    ensure   => present,
-    baseurl  => 'http://packages.partek.com/redhat/unstable/$basearch',
-    enabled  => 0,
-    gpgcheck => 0,
-    gpgkey   => 'file:///etc/pki/rpm-gpg/partek-public.key',
-    require  => Gpg_key['partek-public.key'],
-  }
-  yumrepo { 'partekrepo-noarch-unstable':
-    ensure   => present,
-    baseurl  => 'http://packages.partek.com/redhat/unstable/noarch',
-    enabled  => 0,
-    gpgcheck => 0,
-    gpgkey   => 'file:///etc/pki/rpm-gpg/partek-public.key',
-    require  => Gpg_key['partek-public.key'],
-  }
-  package { $::partekflow::package_name:
-    ensure  => $::partekflow::package_ensure,
-    require => [ User[$::partekflow::user_name], Yumrepo['partekrepo-stable'], Yumrepo['partekrepo-noarch-stable'], ],
+  else {
+    package { $::partekflow::package_name:
+      ensure  => $::partekflow::package_ensure,
+      require => User[$::partekflow::user_name],
+    }
+
   }
 }

--- a/spec/classes/partekflow_spec.rb
+++ b/spec/classes/partekflow_spec.rb
@@ -422,6 +422,103 @@ describe 'partekflow' do
 
           it { expect { is_expected.to contain_user('flow') }.to raise_error(Puppet::Error, /'user_uid' expects an Integer\[1, 999\] value, got Integer\[1000, 1000\]/) }
         end
+
+        context "partekflow class with yumrepo_baseurl_server set to http://yum.example.com" do
+          let(:params){
+            {
+              :yumrepo_baseurl_server => 'http://yum.example.com',
+            }
+          }
+
+          it { is_expected.to contain_yumrepo('partekrepo-stable').with_baseurl('http://yum.example.com/redhat/stable/$basearch') }
+          it { is_expected.to contain_yumrepo('partekrepo-noarch-stable').with_baseurl('http://yum.example.com/redhat/stable/noarch') }
+          it { is_expected.to contain_yumrepo('partekrepo-unstable').with_baseurl('http://yum.example.com/redhat/unstable/$basearch') }
+          it { is_expected.to contain_yumrepo('partekrepo-noarch-unstable').with_baseurl('http://yum.example.com/redhat/unstable/noarch') }
+        end
+
+        context "partekflow class with yumrepo_baseurl_stablepath set to /foo/stabler" do
+          let(:params){
+            {
+              :yumrepo_baseurl_stablepath => '/foo/stabler',
+            }
+          }
+
+          it { is_expected.to contain_yumrepo('partekrepo-stable').with_baseurl('http://packages.partek.com/foo/stabler/$basearch') }
+          it { is_expected.to contain_yumrepo('partekrepo-noarch-stable').with_baseurl('http://packages.partek.com/foo/stabler/noarch') }
+        end
+
+        context "partekflow class with yumrepo_baseurl_unstablepath set to /foo/unstabler" do
+          let(:params){
+            {
+              :yumrepo_baseurl_unstablepath => '/foo/unstabler',
+            }
+          }
+
+          it { is_expected.to contain_yumrepo('partekrepo-unstable').with_baseurl('http://packages.partek.com/foo/unstabler/$basearch') }
+          it { is_expected.to contain_yumrepo('partekrepo-noarch-unstable').with_baseurl('http://packages.partek.com/foo/unstabler/noarch') }
+        end
+
+        context "partekflow class with yumrepo_enabled_stable set to false" do
+          let(:params){
+            {
+              :yumrepo_enabled_stable => false,
+            }
+          }
+
+          it { is_expected.to contain_yumrepo('partekrepo-stable').with_enabled('0') }
+          it { is_expected.to contain_yumrepo('partekrepo-noarch-stable').with_enabled('0') }
+        end
+
+        context "partekflow class with yumrepo_enabled_unstable set to true" do
+          let(:params){
+            {
+              :yumrepo_enabled_unstable => true,
+            }
+          }
+
+          it { is_expected.to contain_yumrepo('partekrepo-unstable').with_enabled('1') }
+          it { is_expected.to contain_yumrepo('partekrepo-noarch-unstable').with_enabled('1') }
+        end
+
+        context "partekflow class with yumrepo_ensure_stable set to false" do
+          let(:params){
+            {
+              :yumrepo_ensure_stable => false,
+            }
+          }
+
+          it { is_expected.to contain_yumrepo('partekrepo-stable').with_ensure('absent') }
+          it { is_expected.to contain_yumrepo('partekrepo-noarch-stable').with_ensure('absent') }
+        end
+
+        context "partekflow class with yumrepo_ensure_unstable set to true" do
+          let(:params){
+            {
+              :yumrepo_ensure_unstable => true,
+            }
+          }
+
+          it { is_expected.to contain_yumrepo('partekrepo-unstable').with_ensure('present') }
+          it { is_expected.to contain_yumrepo('partekrepo-noarch-unstable').with_ensure('present') }
+        end
+
+        context "partekflow class with yumrepo_manage set to false" do
+          let(:params){
+            {
+              :yumrepo_manage => false,
+            }
+          }
+
+          it { is_expected.to_not contain_yumrepo('partekrepo-stable') }
+          it { is_expected.to_not contain_yumrepo('partekrepo-noarch-stable') }
+          it { is_expected.to_not contain_yumrepo('partekrepo-unstable') }
+          it { is_expected.to_not contain_yumrepo('partekrepo-noarch-unstable') }
+          it { is_expected.to contain_package('partekflow').with(
+            'ensure'  => 'present',
+            'require' => 'User[flow]',
+          ) }
+        end
+
       end
     end
   end


### PR DESCRIPTION
While the module allows for creation of the Partek repositories, it's pretty opinionated... i.e. only stable, always enabled, URL at partek, etc. These need to be parameterized to allow for more flexibility.