### PR TITLE
Added in yaml-lint support to Gemfile, Rakefile, and .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
----
 sudo: false
 language: ruby
 cache: bundler
@@ -16,19 +15,16 @@ matrix:
   fast_finish: true
   include:
     - rvm: 2.1.9
-      bundler_args: --without system_tests development
+      bundler_args: "--without system_tests development"
+      env: PUPPET_VERSION="~> 4.0" CHECK=yaml_lint
+    - rvm: 2.1.9
+      bundler_args: "--without system_tests development"
       env: PUPPET_VERSION="~> 4.7.0" CHECK=test
     - rvm: 2.1.9
-      bundler_args: --without system_tests development
-      env: PUPPET_VERSION="~> 4.8.0" CHECK=test
-    - rvm: 2.1.9
-      bundler_args: --without system_tests development
-      env: PUPPET_VERSION="~> 4.9.0" CHECK=test
-    - rvm: 2.1.9
-      bundler_args: --without system_tests development
+      bundler_args: "--without system_tests development"
       env: PUPPET_VERSION="~> 4.10.0" CHECK=test
     - rvm: 2.4.1
-      bundler_args: --without system_tests development
+      bundler_args: "--without system_tests development"
       env: PUPPET_VERSION="~> 5.0" CHECK=test
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,21 +15,34 @@ matrix:
   fast_finish: true
   include:
     - rvm: 2.1.9
-      bundler_args: "--without system_tests development"
+      bundler_args: --without system_tests development
       env: PUPPET_VERSION="~> 4.0" CHECK=yaml_lint
     - rvm: 2.1.9
-      bundler_args: "--without system_tests development"
+      bundler_args: --without system_tests development
       env: PUPPET_VERSION="~> 4.7.0" CHECK=test
     - rvm: 2.1.9
-      bundler_args: "--without system_tests development"
+      bundler_args: --without system_tests development
       env: PUPPET_VERSION="~> 4.10.0" CHECK=test
     - rvm: 2.4.1
-      bundler_args: "--without system_tests development"
+      bundler_args: --without system_tests development
       env: PUPPET_VERSION="~> 5.0" CHECK=test
+    - rvm: 2.4.1
+      bundler_args: --without system_tests development
+      env: PUPPET_VERSION="~> 5.0" CHECK=test DEPLOY_TO_FORGE=yes
 branches:
   only:
     - master
     - /^v\d/
 notifications:
-  email:
-    - millerjl1701@gmail.com
+  email: false
+deploy:
+  provider: puppetforge
+  user: millerjl1701
+  password:
+    secure: ECgDojKqY/Sn9j3aPBkGwtfSPPgmpXbR/3K79lrSe7C8nJ/QC1xz+vxirN+QDBLu1ZUh+YQRa1Ie1VuPifEiwcOpdtH5opkB/d0K5Sw2pr+KKodOBFUkV8Rm81s8h9A34FJOt+iYuVxUmhrLa+edbUmQXv8p7otu/V7K5gdwXJvBZ7roYTGUCl4xJihN4dsJnuAH/u6lCKibwYL9F9PS+Lew6TgkYdHccT9J9W3j9NypEsaoaCvWy2DasPN3Icpricfy3/kEK7JqylJEmDY3+s3cUaOyE7sAw08PPx4VuB8eu0QJmCmxQsnXqVc+gKKVGqPJwhjYf9t0gdEEDUW52Ub/iEOQQTLS54Xnlkz90Imq7Xho6hWSzgejNopk9Ln6LEHAac8BJR06ajGZk0idjDUSl0kIfnzmqSBMX0/CGXPPp0Aen6s5+K2gxD20rUCoHc7gaA7zZDGfpEkFlTC1QVoImyI8j94UDv8DoDBgMq2Uq2PFB049OcASaAIssrSGyPmTfuRlashunVmHetQN+368JdNkNnwj4TVYc2R2nJs0mKR9uLNgSJuey+INVm87d9MwKI14KVwKAWh6BQI37Y7qKkFCgTQm29jWCgqfJNTUEqbiVRQbmhquv87uLWDvQTHzlc2btpkDTr2tszPLKClWGm5alZYfBNqqA/+VX04=
+  on:
+    tags: true
+    # all_branches is required to use tags
+    all_branches: true
+    # Only publish the build marked with "DEPLOY_TO_FORGE"
+    condition: "$DEPLOY_TO_FORGE = yes"

--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,8 @@ group :test do
   gem 'puppet-lint-classes_and_types_beginning_with_digits-check',  :require => false
   gem 'puppet-lint-unquoted_string-check',                          :require => false
   gem 'puppet-lint-variable_contains_upcase',                       :require => false
+
+  gem 'yaml-lint'
 end
 
 group :development do

--- a/Rakefile
+++ b/Rakefile
@@ -45,6 +45,11 @@ task :contributors do
   system("git log --format='%aN <%aE>' | sort -u > CONTRIBUTORS")
 end
 
+desc "Run yaml-lint"
+task :yaml_lint do
+    sh "yaml-lint data"
+end
+
 desc "Run syntax, lint, and spec tests."
 task :test => [
   :metadata_lint,


### PR DESCRIPTION
Added in yaml-lint support to Gemfile, Rakefile, and .travis.yml. Removed excess test items for puppet 4.8 and 4.9 since they were redundant with 4.7 and 4.10 respectively. 